### PR TITLE
Fix enhancement tagging in body

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -44,7 +44,8 @@ const updateTokenForm = `
 </html>
 `
 
-var enhancementRegexp = regexp.MustCompile("feature.?request|enhancement")
+var enhancementRegexp = regexp.MustCompile(`\[\s*x\s*\]\s*feature\s*request`)
+var enhancementRegexpTitle = regexp.MustCompile("feature.?request|enhancement")
 
 func init() {
 	http.HandleFunc("/issues", issuesHandler)
@@ -416,7 +417,7 @@ func issuesHandler(w http.ResponseWriter, r *http.Request) {
 	lcTitle := strings.ToLower(*payload.Issue.Title)
 
 	if *payload.Action == "opened" &&
-		(enhancementRegexp.MatchString(lcBody) || enhancementRegexp.MatchString(lcTitle)) {
+		(enhancementRegexp.MatchString(lcBody) || enhancementRegexpTitle.MatchString(lcTitle)) {
 		// For feature requests, add the enhancement label, but only on creation.
 		// Skip all the other checks.
 		addLabel(ctx, githubclient, payload, w, "enhancement")


### PR DESCRIPTION
@stapelberg With the changes to the issue template, all new tickets are tagged as an enhancement, e.g. https://github.com/i3/i3/issues/3296.

I made these changes now, but couldn't test them – is there a good way I could do this upfront? I wonder whether it'd be easier to move to some bot platform instead of rolling our own bot for this as well… the README mentions the attachment hosting, but Github does allow attaching files by now.